### PR TITLE
Possible to start at a specific view controller

### DIFF
--- a/NestedPageViewController/DVANestedPageViewController/DVANestedPageViewController.h
+++ b/NestedPageViewController/DVANestedPageViewController/DVANestedPageViewController.h
@@ -35,7 +35,7 @@ extern const void *DVANestedPageViewControllerPositionKey;
 @property (nonatomic, strong, readonly) NSIndexPath *currentIndexPath;
 @property (nonatomic, weak) IBOutlet id<DVANestedPageViewControllerDataSource> dataSource;
 @property (nonatomic, weak) IBOutlet id<DVANestedPageViewControllerDelegate> delegate;
-@property (nonatomic, readwrite) NSUInteger initialPosition;
+@property (nonatomic, readwrite) NSInteger initialPosition;
 
 - (void)reloadData;
 - (void)scrollToIndexPath:(NSIndexPath *)indexPath;

--- a/NestedPageViewController/DVANestedPageViewController/DVANestedPageViewController.h
+++ b/NestedPageViewController/DVANestedPageViewController/DVANestedPageViewController.h
@@ -35,6 +35,7 @@ extern const void *DVANestedPageViewControllerPositionKey;
 @property (nonatomic, strong, readonly) NSIndexPath *currentIndexPath;
 @property (nonatomic, weak) IBOutlet id<DVANestedPageViewControllerDataSource> dataSource;
 @property (nonatomic, weak) IBOutlet id<DVANestedPageViewControllerDelegate> delegate;
+@property (nonatomic, readwrite) NSUInteger initialPosition;
 
 - (void)reloadData;
 - (void)scrollToIndexPath:(NSIndexPath *)indexPath;

--- a/NestedPageViewController/DVANestedPageViewController/DVANestedPageViewController.m
+++ b/NestedPageViewController/DVANestedPageViewController/DVANestedPageViewController.m
@@ -74,7 +74,14 @@ const void *DVANestedPageViewControllerPositionKey = &DVANestedPageViewControlle
 - (void)loadViewControllers
 {
     if ([self.sections unsignedIntegerValue] > 0) {
-        NSArray *viewControllers = @[[self viewControllerAtSection:0]];
+        NSUInteger initialSectionNumber = 0;
+
+        NSUInteger proposedInitialSectionNumber = self.initialPosition;
+        if (proposedInitialSectionNumber <= [self.sections unsignedIntegerValue]) {
+            initialSectionNumber = proposedInitialSectionNumber;
+        }
+
+        NSArray *viewControllers = @[[self viewControllerAtSection:initialSectionNumber]];
         [self.pageViewController setViewControllers:viewControllers direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
     }
 }

--- a/NestedPageViewController/DVANestedPageViewController/DVANestedPageViewController.m
+++ b/NestedPageViewController/DVANestedPageViewController/DVANestedPageViewController.m
@@ -76,9 +76,9 @@ const void *DVANestedPageViewControllerPositionKey = &DVANestedPageViewControlle
     if ([self.sections unsignedIntegerValue] > 0) {
         NSUInteger initialSectionNumber = 0;
 
-        NSUInteger proposedInitialSectionNumber = self.initialPosition;
-        if (proposedInitialSectionNumber <= [self.sections unsignedIntegerValue]) {
-            initialSectionNumber = proposedInitialSectionNumber;
+        if (self.initialPosition > 0 && self.initialPosition <= [self.sections unsignedIntegerValue]) {
+            initialSectionNumber = self.initialPosition;
+            self.initialPosition = -1;
         }
 
         NSArray *viewControllers = @[[self viewControllerAtSection:initialSectionNumber]];


### PR DESCRIPTION
By setting this property `initialPosition` you can start the nested page view controller at a specific section.

When using _Storyboards_ you can set a _User Defined Runtime Attribute_ with key `initialPosition`, Type `Number` and Value to what ever number you fancy.

Setting the `initialPosition` to a negative or too high a number will effectively disable it. 
